### PR TITLE
Fix state assignments in HMM submodels

### DIFF
--- a/deeptime/markov/__init__.py
+++ b/deeptime/markov/__init__.py
@@ -28,6 +28,8 @@ Utilities
     :toctree: generated/
     :template: class_nomodule.rst
 
+    map_dtrajs_to_symbols
+
     number_of_states
     count_states
     compute_connected_sets
@@ -39,10 +41,13 @@ Utilities
     sample.compute_index_states
     sample.indices_by_sequence
     sample.indices_by_state
+
+    DiscreteStatesManager
 """
 
 from ._util import number_of_states, count_states, compute_connected_sets, \
     compute_dtrajs_effective, compute_effective_stride
+from ._discrete_states import map_dtrajs_to_symbols, DiscreteStatesManager
 from . import sample
 from . import tools  # former msmtools
 

--- a/deeptime/markov/_discrete_states.py
+++ b/deeptime/markov/_discrete_states.py
@@ -1,0 +1,160 @@
+import numpy as np
+
+from deeptime.util.types import ensure_dtraj_list
+
+
+def map_dtrajs_to_symbols(dtrajs, state_symbols: np.ndarray, n_states_full: int,
+                          empty_symbol: np.int32 = -1, check=False):
+    r"""A list of integer arrays with the discrete trajectories mapped to the currently used set of symbols.
+
+    Parameters
+    ----------
+    dtrajs : array_like or list of array_like
+        discretized trajectories
+    state_symbols : ndarray
+        the state symbols to restrict to
+    n_states_full : int
+        Total number of states.
+    empty_symbol: np.int32, optional, default=-1
+        The artificial state that is mapped to, if it is not contained in state_symbols.
+    check : bool, default=False
+        Whether to convert the input dtrajs to list of dtrajs or assume it is a list of dtrajs already.
+
+    Returns
+    -------
+    transformed_dtrajs : List[np.ndarray]
+        Mapped dtrajs.
+    """
+    if check:
+        dtrajs = ensure_dtraj_list(dtrajs)
+    mapping = np.full(n_states_full, empty_symbol, dtype=np.int32)
+    mapping[state_symbols] = np.arange(len(state_symbols))
+    return [mapping[dtraj] for dtraj in dtrajs]
+
+
+class DiscreteStatesManager:
+
+    def __init__(self, state_symbols: np.ndarray, n_states_full: int, blank_state=-1):
+        self._blank_state = blank_state
+        self._state_symbols = state_symbols
+        self._n_states_full = n_states_full
+        self._state_symbols_with_blank = np.concatenate((state_symbols, (blank_state,)))
+
+        if self.n_states_full < self.n_states:
+            # full number of states must be at least as large as n_states
+            raise ValueError(f"Number of states was bigger than full number of "
+                             f"states. (#states = {self.n_states}, #states_full = {self.n_states_full}).")
+
+    @property
+    def n_states(self):
+        return len(self.state_symbols)
+
+    @property
+    def n_states_full(self):
+        return self._n_states_full
+
+    @property
+    def states(self) -> np.ndarray:
+        r""" The states in this model, i.e., a iota range from 0 (inclusive) to :meth:`n_states` (exclusive).
+        See also: :meth:`state_symbols`. """
+        return np.arange(self.n_states)
+
+    @property
+    def state_symbols(self) -> np.ndarray:
+        r""" Symbols for states that are represented in this count model. """
+        return self._state_symbols_with_blank[:-1]
+
+    @property
+    def state_symbols_with_blank(self):
+        r""" Symbols for states that are represented in this count model plus a state `blank` for states which are
+        not represented in this count model. """
+        return self._state_symbols_with_blank
+
+    @property
+    def blank_state(self):
+        return self._blank_state
+
+    @property
+    def is_full(self) -> bool:
+        r""" Determine whether this counting model refers to the full model that represents all states of the data.
+
+        Returns
+        -------
+        is_full_model : bool
+            Whether this counting model represents all states of the data.
+        """
+        return self.n_states == self.n_states_full
+
+    @property
+    def selected_state_fraction(self) -> float:
+        """The represented fraction of states."""
+        return float(self.n_states) / float(self.n_states_full)
+
+    def project(self, dtrajs, check=False):
+        r"""A list of integer arrays with the discrete trajectories mapped to the currently used set of symbols.
+        For example, if there has been a subselection of the model for connectivity='largest', the indices will be
+        given within the connected set, frames that do not correspond to a considered symbol are set to -1.
+
+        Parameters
+        ----------
+        dtrajs : array_like or list of array_like
+            Discretized trajectories.
+        check : bool, optional, default=False
+            Whether to check the dtrajs input for validity.
+
+        Returns
+        -------
+        array_like or list of array_like
+            Curated discretized trajectories so that unconsidered symbols are mapped to -1.
+        """
+
+        if self.is_full:
+            # no-op
+            return dtrajs
+        else:
+            return map_dtrajs_to_symbols(dtrajs, self.state_symbols, self.n_states_full, check=check)
+
+    def states_to_symbols(self, states: np.ndarray) -> np.ndarray:
+        r""" Converts a list of states to a list of symbols which can be related back to the original data.
+
+        Parameters
+        ----------
+        states : (N,) ndarray
+            Array of states.
+
+        Returns
+        -------
+        symbols : (N,) ndarray
+            Array of symbols.
+        """
+        return self.state_symbols_with_blank[states]
+
+    def symbols_to_states(self, symbols):
+        r"""
+        Converts a set of symbols to state indices in this count model instance. The symbols which
+        are no longer present in this model are discarded. It can happen that the order is
+        changed or the result is smaller than the input length.
+
+        Parameters
+        ----------
+        symbols : array_like
+            the symbols to be mapped to state indices
+
+        Returns
+        -------
+        states : ndarray
+            An array of states.
+        """
+        # only take symbols which are still present in this model
+        if isinstance(symbols, set):
+            symbols = list(symbols)
+        symbols = np.intersect1d(np.asarray(symbols), self.state_symbols)
+        return np.argwhere(np.isin(self.state_symbols, symbols)).flatten()
+
+    def subselect_states(self, states: np.ndarray):
+        states = np.atleast_1d(states)
+        sub_symbols = self.state_symbols[states]
+        return DiscreteStatesManager(sub_symbols, self.n_states_full, self.blank_state)
+
+    def __len__(self):
+        return len(self.state_symbols)

--- a/deeptime/markov/_discrete_states.py
+++ b/deeptime/markov/_discrete_states.py
@@ -33,7 +33,20 @@ def map_dtrajs_to_symbols(dtrajs, state_symbols: np.ndarray, n_states_full: int,
 
 
 class DiscreteStatesManager:
+    r"""Class that manages discrete states. Resolves mapping between state symbols and states;
+        contains functions for mapping to a subset (e.g. an active (connected) set of an MSM).
 
+       Parameters
+       ----------
+       state_symbols : ndarray
+            array that contains the integer state symbols used in a model
+        n_states_full : int
+            number of full states in the modeled state space
+        blank_state : int, optional, default=-1
+            definition of the blank or empty state used to map observations to that are not part of the set of
+            state symbols.
+
+       """
     def __init__(self, state_symbols: np.ndarray, n_states_full: int, blank_state=-1):
         self._blank_state = blank_state
         self._state_symbols = state_symbols
@@ -47,10 +60,24 @@ class DiscreteStatesManager:
 
     @property
     def n_states(self):
+        r"""
+        Property to determine the number of observed states or state symbols that are part of the active set.
+
+        Returns
+        -------
+        Number of observed states in active set
+        """
         return len(self.state_symbols)
 
     @property
     def n_states_full(self):
+        r"""
+        Property to determine the number of observed states or state symbols in all data.
+
+        Returns
+        -------
+        Number of observed states
+        """
         return self._n_states_full
 
     @property
@@ -72,6 +99,13 @@ class DiscreteStatesManager:
 
     @property
     def blank_state(self):
+        r"""
+        Property that holds the blank state, i.e. the symbol that denotes an inactive state.
+
+        Returns
+        -------
+        blank state symbol
+        """
         return self._blank_state
 
     @property
@@ -131,7 +165,7 @@ class DiscreteStatesManager:
 
     def symbols_to_states(self, symbols):
         r"""
-        Converts a set of symbols to state indices in this count model instance. The symbols which
+        Converts a set of symbols to state indices. The symbols which
         are no longer present in this model are discarded. It can happen that the order is
         changed or the result is smaller than the input length.
 
@@ -152,6 +186,18 @@ class DiscreteStatesManager:
         return np.argwhere(np.isin(self.state_symbols, symbols)).flatten()
 
     def subselect_states(self, states: np.ndarray):
+        r"""
+        Creates a new instance of a DiscreteStatesManager with a subset of states
+        Parameters
+        ----------
+        states : ndarray
+            the selection of states to create a new DiscreteStatesManager for
+
+        Returns
+        -------
+        DiscreteStatesManager
+            Discrete states manager for subselection
+        """
         states = np.atleast_1d(states)
         sub_symbols = self.state_symbols[states]
         return DiscreteStatesManager(sub_symbols, self.n_states_full, self.blank_state)

--- a/deeptime/markov/hmm/_bindings/include/deeptime/markov/hmm/OutputModelUtils.h
+++ b/deeptime/markov/hmm/_bindings/include/deeptime/markov/hmm/OutputModelUtils.h
@@ -90,6 +90,15 @@ np_array<dtype> toOutputProbabilityTrajectory(const np_array_nfc<State> &observa
     const auto* P = outputProbabilities.data();
     const auto* obs = observations.data();
 
+    if(std::any_of(obs, obs + observations.size(), [nObs](const auto &o) {
+        return o < 0 || o >= static_cast<State>(nObs);
+    })) {
+        std::stringstream ss;
+        ss << "At least one observation in the provided dtrajs contains an observation state which is not present "
+              "in the HMM observable set (0 through " << nObs - 1 << ").";
+        throw std::runtime_error(ss.str());
+    }
+
     np_array<dtype> output(std::vector<std::size_t>{static_cast<std::size_t>(observations.shape(0)), nHidden});
     auto* outputPtr = output.mutable_data();
     auto T = observations.shape(0);

--- a/deeptime/markov/hmm/_hidden_markov_model.py
+++ b/deeptime/markov/hmm/_hidden_markov_model.py
@@ -413,7 +413,7 @@ class HiddenMarkovModel(Model):
         """
         return -self.transition_model.lagtime / np.log(np.diag(self.transition_model.transition_matrix))
 
-    def compute_viterbi_paths(self, observations) -> List[np.ndarray]:
+    def compute_viterbi_paths(self, observations, map_observations_to_submodel: bool = False) -> List[np.ndarray]:
         r"""
         Computes the Viterbi paths using the current HMM model.
 
@@ -428,6 +428,8 @@ class HiddenMarkovModel(Model):
             the computed viterbi paths
         """
         observations = ensure_dtraj_list(observations)
+        if map_observations_to_submodel and isinstance(self.output_model, DiscreteOutputModel):
+            observations = self.output_model.map_observations_to_submodel(observations)
         A = self.transition_model.transition_matrix
         pi = self.initial_distribution
         state_probabilities = [

--- a/deeptime/markov/hmm/_hidden_markov_model.py
+++ b/deeptime/markov/hmm/_hidden_markov_model.py
@@ -417,10 +417,17 @@ class HiddenMarkovModel(Model):
         r"""
         Computes the Viterbi paths using the current HMM model.
 
+        Note:
+        In  case of sub-modeling a discrete state HMM, the observation sequence must be mapped to the active states of
+        that sub-model. This can either be done by hand beforehand or by activating the map_observations_to_submodel
+        flag.
+
         Parameters
         ----------
         observations : list of array_like or array_like
             observations
+        map_observations_to_submodel : bool, optional, default = False
+            If True and in case of a discrete output model, activates automatic mapping to the active sub-model states
 
         Returns
         -------

--- a/deeptime/markov/hmm/_output_model.py
+++ b/deeptime/markov/hmm/_output_model.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 
 import numpy as np
 from ._hmm_bindings import output_models as _bindings
+from .. import map_dtrajs_to_symbols, DiscreteStatesManager
 
 from ...base import Model
 
@@ -178,7 +179,7 @@ class DiscreteOutputModel(OutputModel):
         Whether to ignore outliers, see :attr:`ignore_outliers`.
     """
     def __init__(self, output_probabilities: np.ndarray, prior: Optional[np.ndarray] = None,
-                 ignore_outliers: bool = False):
+                 ignore_outliers: bool = False, discrete_states_manager=None):
         if output_probabilities.ndim != 2:
             raise ValueError("Discrete output model requires two-dimensional output probability matrix!")
         if np.any(output_probabilities < 0) or not np.allclose(output_probabilities.sum(axis=-1), 1.):
@@ -194,6 +195,13 @@ class DiscreteOutputModel(OutputModel):
                              f"!= {output_probabilities.shape}.")
         self._output_probabilities = output_probabilities
         self._prior = prior
+        if discrete_states_manager is None:
+            discrete_states_manager = DiscreteStatesManager(np.arange(self.n_observable_states),
+                                                            self.n_observable_states)
+        self._discrete_states_manager = discrete_states_manager
+
+    def map_observations_to_submodel(self, observations: np.ndarray):
+        return self._discrete_states_manager.project(observations, check=True)
 
     @property
     def prior(self) -> np.ndarray:
@@ -253,7 +261,8 @@ class DiscreteOutputModel(OutputModel):
             prior = np.copy(self.prior[np.ix_(states, obs)])
         else:
             prior = None
-        return DiscreteOutputModel(B, prior, self.ignore_outliers)
+        return DiscreteOutputModel(B, prior, self.ignore_outliers,
+                                   self._discrete_states_manager.subselect_states(obs))
 
     def sample(self, observations_per_state: List[np.ndarray]) -> None:
         r"""

--- a/deeptime/markov/hmm/_output_model.py
+++ b/deeptime/markov/hmm/_output_model.py
@@ -177,6 +177,7 @@ class DiscreteOutputModel(OutputModel):
         to :math:`a_{ij} = 0`. This option ensures coincidence between sample mean an MLE.
     ignore_outliers : bool, optional, default=False
         Whether to ignore outliers, see :attr:`ignore_outliers`.
+    discrete_states_manager : DiscreteStatesManager, optional, default=None
     """
     def __init__(self, output_probabilities: np.ndarray, prior: Optional[np.ndarray] = None,
                  ignore_outliers: bool = False, discrete_states_manager=None):
@@ -201,6 +202,19 @@ class DiscreteOutputModel(OutputModel):
         self._discrete_states_manager = discrete_states_manager
 
     def map_observations_to_submodel(self, observations: np.ndarray):
+        r"""
+        Map a sequence of observations to the reduced state space of a sub-model.
+
+        Parameters
+        ----------
+        observations : ndarray
+            sequence of observations
+
+        Returns
+        ----------
+        mapped_observations : ndarray
+            array containing mapped observation sequence
+        """
         return self._discrete_states_manager.project(observations, check=True)
 
     @property

--- a/deeptime/markov/sample/__init__.py
+++ b/deeptime/markov/sample/__init__.py
@@ -6,7 +6,7 @@ from deeptime.util.types import ensure_dtraj_list
 
 
 def compute_index_states(dtrajs, subset=None) -> List[np.ndarray]:
-    """Generates a trajectory/time indices for the given list of states
+    """Generates trajectory/time indices for the given list of states
 
     Parameters
     ----------

--- a/tests/markov/test_discrete_states.py
+++ b/tests/markov/test_discrete_states.py
@@ -2,7 +2,6 @@ import unittest
 
 from deeptime.markov import DiscreteStatesManager
 import numpy as np
-import pytest
 
 from numpy.testing import assert_equal, assert_array_equal, assert_
 
@@ -89,4 +88,3 @@ class TestDiscreteStateManager(unittest.TestCase):
         assert_array_equal(self.sel_dsm.states_to_symbols(self.states), np.array([0, 5, -1]))
         # function discards states that are not in selection
         assert_array_equal(self.sel_dsm.symbols_to_states(self.state_symbols), [0, 1])
-

--- a/tests/markov/test_discrete_states.py
+++ b/tests/markov/test_discrete_states.py
@@ -1,0 +1,92 @@
+import unittest
+
+from deeptime.markov import DiscreteStatesManager
+import numpy as np
+import pytest
+
+from numpy.testing import assert_equal, assert_array_equal, assert_
+
+
+class TestDiscreteStateManagerIdentityMap(unittest.TestCase):
+    r""" Checks if DiscreteStatesManager maps states to symbols in a case where both are the same.
+    """
+
+    def setUp(self) -> None:
+        self.dtraj = np.array([0, 0, 0, 1, 0, 1, 1])
+        self.state_symbols = np.array([0, 1])
+        self.states = self.state_symbols.copy()
+        self.n_states_full = 2
+        self.dsm = DiscreteStatesManager(self.state_symbols, self.n_states_full)
+
+    def test_statenumbers(self):
+        assert_equal(self.dsm.n_states, self.n_states_full)
+        assert_equal(self.dsm.n_states_full, self.n_states_full)
+
+    def test_states_symbols(self):
+        assert_(self.dsm.is_full)
+        assert_array_equal(self.dsm.states, self.states)
+        assert_array_equal(self.dsm.state_symbols, self.state_symbols)
+
+    def test_mappings(self):
+        assert_array_equal(self.dsm.project(self.dtraj), self.dtraj)
+        assert_array_equal(self.dsm.states_to_symbols(self.states), self.state_symbols)
+        assert_array_equal(self.dsm.symbols_to_states(self.state_symbols), self.states)
+
+    def test_subselect(self):
+        new_dsm = self.dsm.subselect_states(np.array([0]))
+        assert_equal(len(new_dsm), 1)
+
+
+class TestDiscreteStateManager(unittest.TestCase):
+    """ Checks if DiscreteStatesManager maps states to symbols for a case of non-contiguous symbols.
+        Also tests if sub-selecting states reproduces expectable results.
+    """
+
+    def setUp(self) -> None:
+        self.dtraj = np.array([0, 0, 0, 5, 0, 5, 5, 10, 10])
+        self.state_symbols = np.array([0, 5, 10])
+        self.states = np.array([0, 1, 2])
+        self.n_states_full = 25
+        self.dsm = DiscreteStatesManager(self.state_symbols, self.n_states_full)
+
+        self.sel_states = np.array([0, 1])
+        self.sel_state_symbols = np.array([0, 5])
+        self.sel_dsm = self.dsm.subselect_states(self.sel_states)
+
+    def test_statenumbers(self):
+        assert_(not self.dsm.is_full)
+        assert_equal(self.dsm.n_states, len(self.states))
+
+    def test_states_symbols(self):
+        assert_array_equal(self.dsm.states, self.states)
+        assert_array_equal(self.dsm.state_symbols, self.state_symbols)
+
+    def test_mappings(self):
+        projected_dtraj = (self.dtraj/5).astype(int)
+        assert_array_equal(self.dsm.project(self.dtraj), projected_dtraj)
+        assert_array_equal(self.dsm.states_to_symbols(self.states), self.state_symbols)
+        assert_array_equal(self.dsm.symbols_to_states(self.state_symbols), self.states)
+
+    def test_subselect_statenumbers(self):
+        assert_array_equal(self.sel_dsm.states, self.sel_states)
+        assert_array_equal(self.sel_dsm.state_symbols, self.sel_state_symbols)
+
+    def test_subselect_states_symbols(self):
+        assert_array_equal(self.sel_dsm.states, self.sel_states)
+        assert_array_equal(self.sel_dsm.state_symbols, self.sel_state_symbols)
+
+    def test_subselect_mappings(self):
+        # tests only states contained in state selection
+        projected_dtraj = (self.dtraj/5).astype(int)[:6]
+        assert_array_equal(self.sel_dsm.project(self.dtraj[:6]), projected_dtraj[:6])
+        assert_array_equal(self.sel_dsm.states_to_symbols(self.sel_states), self.sel_state_symbols)
+        assert_array_equal(self.sel_dsm.symbols_to_states(self.sel_state_symbols), self.sel_states)
+
+    def test_subselect_mappings_with_outliers(self):
+        projected_dtraj = (self.dtraj/5).astype(int)
+        projected_dtraj[projected_dtraj == 2] = -1
+        assert_array_equal(self.sel_dsm.project(self.dtraj), projected_dtraj)
+        assert_array_equal(self.sel_dsm.states_to_symbols(self.states), np.array([0, 5, -1]))
+        # function discards states that are not in selection
+        assert_array_equal(self.sel_dsm.symbols_to_states(self.state_symbols), [0, 1])
+


### PR DESCRIPTION
**Issue:**
When calling the `submodel()` method of a `MaximumLikelihoodHMM`, the user API was inconsistent: a) sampling states using a sequence of observations could be done using the original state symbols (with `sample_by_observation_probabilities`), b) Viterbi path computation did not work in the original state symbols anymore (with `compute_viterbi_paths`, which also did not throw an error). 

**Fix:**
- new `DiscreteStatesManager` class for keeping track of mapping between states and state symbols (and subsets thereof).
- User can choose to map trajectories to subset automatically in `compute_viterbi_paths` call
- consistency check for states that are not in the HMM-set in Viterbi implementation

Thanks @clonker !!