### PR TITLE
add device option for TAE class

### DIFF
--- a/deeptime/decomposition/deep/_tae.py
+++ b/deeptime/decomposition/deep/_tae.py
@@ -99,10 +99,11 @@ class TAE(EstimatorTransformer, DLEstimatorMixin):
     """
     _MUTABLE_INPUT_DATA = True
 
-    def __init__(self, encoder: nn.Module, decoder: nn.Module, optimizer='Adam', learning_rate=3e-4):
+    def __init__(self, encoder: nn.Module, decoder: nn.Module, optimizer='Adam', learning_rate=3e-4, device='cpu'):
         super().__init__()
-        self._encoder = encoder
-        self._decoder = decoder
+        self.device = device
+        self._encoder = encoder.to(self.device)
+        self._decoder = decoder.to(self.device)
         self.learning_rate = learning_rate
         self.setup_optimizer(optimizer, list(encoder.parameters()) + list(decoder.parameters()))
         self._mse_loss = nn.MSELoss(reduction='sum')


### PR DESCRIPTION
Hi! I just found the device of the TAE class is not allowed to be specified when I was playing the time-lagged auto-encoder. After checked the code, I found a self.device actually does appear in the fit function but without initialization. So I just added an option for device in the init function so that one can choose to use either cpu or gpu to train the model.
