### PR TITLE
Update parallel function according to documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Contributors
 * Brian de Silva
 * Yuxuan Zhuang
 * Wei-Tse Hsu
+* Sian Xiao

--- a/deeptime/util/parallel.py
+++ b/deeptime/util/parallel.py
@@ -24,21 +24,18 @@ def handle_n_jobs(value: Optional[int]) -> int:
     """
     if value is None:
         value = 1
-    elif value <= 0:
-        if value == -1:
-            try:
-                from os import sched_getaffinity
-                count = len(sched_getaffinity(0))
-            except ImportError:
-                from os import cpu_count
-                count = cpu_count()
-            if count is None:
-                raise ValueError("Could not determine number of cpus in system, please provide n_jobs manually.")
-            value = count
-        else:
-            raise ValueError(f"n_jobs can only be -1 (in which case it will be determined from hardware), "
-                         f"a positive number or -1, but was {value}.")
-    assert isinstance(value, int) and value > 0
+    elif value == -1:
+        try:
+            from os import sched_getaffinity
+            count = len(sched_getaffinity(0))
+        except ImportError:
+            from os import cpu_count
+            count = cpu_count()
+        if count is None:
+            raise ValueError("Could not determine number of cpus in system, please provide n_jobs manually.")
+        value = count
+    if not (isinstance(value, int) and value > 0):
+        raise ValueError(f"n_jobs can only be -1 (in which case it will be determined from hardware), None (in which case one will be used) or a positive number, but was {value}.")
     return value
 
 

--- a/deeptime/util/parallel.py
+++ b/deeptime/util/parallel.py
@@ -9,8 +9,8 @@ def handle_n_jobs(value: Optional[int]) -> int:
     In particular, if
 
       * value is None, use 1 job
-      * value is negative, use number cores available * 2
       * value is positive, use value
+      * value is -1, use all
 
     Parameters
     ----------
@@ -23,18 +23,21 @@ def handle_n_jobs(value: Optional[int]) -> int:
         A non-negative integer value describing how many threads can be started simultaneously.
     """
     if value is None:
-        try:
-            from os import sched_getaffinity
-            count = len(sched_getaffinity(0))
-        except ImportError:
-            from os import cpu_count
-            count = cpu_count()
-        if count is None:
-            raise ValueError("Could not determine number of cpus in system, please provide n_jobs manually.")
-        value = count
+        value = 1
     elif value <= 0:
-        raise ValueError(f"n_jobs can only be None (in which case it will be determined from hardware) "
-                         f"or a positive number, but was {value}.")
+        if value == -1:
+            try:
+                from os import sched_getaffinity
+                count = len(sched_getaffinity(0))
+            except ImportError:
+                from os import cpu_count
+                count = cpu_count()
+            if count is None:
+                raise ValueError("Could not determine number of cpus in system, please provide n_jobs manually.")
+            value = count
+        else:
+            raise ValueError(f"n_jobs can only be -1 (in which case it will be determined from hardware), "
+                         f"a positive number or -1, but was {value}.")
     assert isinstance(value, int) and value > 0
     return value
 

--- a/tests/util/test_parallel.py
+++ b/tests/util/test_parallel.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import TestCase
+import numpy as np
+
+from deeptime.util.parallel import handle_n_jobs
+
+
+class TestParallel(TestCase):
+    def test_value_none(self):
+        # use 1 cpu if using None as parameter
+        value = handle_n_jobs(value=None)
+        self.assertEqual(value, 1)
+
+    def test_value_minus1(self):
+        # use all cpus if using -1 as parameter
+        value = handle_n_jobs(value=-1)
+        try:
+            from os import sched_getaffinity
+            count = len(sched_getaffinity(0))
+        except ImportError:
+            from os import cpu_count
+            count = cpu_count()
+        self.assertEqual(value, count)
+
+    def test_value_positive(self):
+        # use exact numbers of cpus if using positive number as parameter
+        value = handle_n_jobs(value=6)
+        self.assertEqual(value, 6)
+    
+    def test_value_negative(self):
+        # raise error if using other negative number as parameter
+        self.assertRaisesRegex(ValueError, 
+                               f"n_jobs can only be -1 \(in which case it will be determined from hardware\), None \(in which case one will be used\) or a positive number, but was -2.",
+                               handle_n_jobs, -2)
+    
+    def test_value_non_integer(self):
+        # raise error if using other positive non-integer as parameter
+        self.assertRaisesRegex(ValueError, 
+                               f"n_jobs can only be -1 \(in which case it will be determined from hardware\), None \(in which case one will be used\) or a positive number, but was 3.5.",
+                               handle_n_jobs, 3.5)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In scikit-learn, we can use n_jobs to specify how many cores we are using, generally -1 for all. This is also in our documentation (for example in clustering methods). However, it doesn't match here and will raise error when using -1.

Here I tried to change it to aligh with documentation. "If -1, use all, if None, use 1."

- [x] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
