### PR TITLE
detach inverse in the VAMPE score

### DIFF
--- a/deeptime/decomposition/deep/_vampnet.py
+++ b/deeptime/decomposition/deep/_vampnet.py
@@ -216,7 +216,8 @@ def vamp_score(data: "torch.Tensor", data_lagged: "torch.Tensor", method='VAMP2'
         # in original paper of VAMPE, inv can be detached from gradient
         c00_sqrt_inv = sym_inverse(c00, epsilon=epsilon, return_sqrt=True, mode=mode).detach()
         ctt_sqrt_inv = sym_inverse(ctt, epsilon=epsilon, return_sqrt=True, mode=mode).detach()
-        koopman = multi_dot([c00_sqrt_inv, c0t, ctt_sqrt_inv]).t()
+        # detach koopman, so that VAMPE is only depedent on the trace
+        koopman = multi_dot([c00_sqrt_inv, c0t, ctt_sqrt_inv]).t().detach()
 
         u, s, v = torch.svd(koopman)
         mask = s > epsilon

--- a/deeptime/decomposition/deep/_vampnet.py
+++ b/deeptime/decomposition/deep/_vampnet.py
@@ -213,8 +213,9 @@ def vamp_score(data: "torch.Tensor", data_lagged: "torch.Tensor", method='VAMP2'
         out = torch.pow(torch.norm(koopman, p='fro'), 2)
     elif method == 'VAMPE':
         c00, c0t, ctt = covariances(data, data_lagged, remove_mean=True)
-        c00_sqrt_inv = sym_inverse(c00, epsilon=epsilon, return_sqrt=True, mode=mode)
-        ctt_sqrt_inv = sym_inverse(ctt, epsilon=epsilon, return_sqrt=True, mode=mode)
+        # in original paper of VAMPE, inv can be detached from gradient
+        c00_sqrt_inv = sym_inverse(c00, epsilon=epsilon, return_sqrt=True, mode=mode).detach()
+        ctt_sqrt_inv = sym_inverse(ctt, epsilon=epsilon, return_sqrt=True, mode=mode).detach()
         koopman = multi_dot([c00_sqrt_inv, c0t, ctt_sqrt_inv]).t()
 
         u, s, v = torch.svd(koopman)


### PR DESCRIPTION
In the original paper, it is stated:

"Another advantage of the VAMP-E based validation score is that it does not involve any inverse
operation of matrices and can be stably computed."

It seems in general, that the `sym_inverse` should be detached from the graph, otherwise it is involved in the computational graph and gradient is calculated through the inverse. In fact, from my point of view, both inverses and `koopman` should be detached from the graph, and only the `torch.trace` part should be contributing to the optimization. 

