### PR TITLE
Implementation of Girsanov reweighting in deeptime MSM estimator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,5 @@ Contributors
 * Yuxuan Zhuang
 * Wei-Tse Hsu
 * Sian Xiao
+* Bettina G. Keller
+* Joana-Lysiane Schäfer

--- a/deeptime/markov/__init__.py
+++ b/deeptime/markov/__init__.py
@@ -14,6 +14,7 @@ Transition counting and analysis tools
 
     TransitionCountEstimator
     TransitionCountModel
+    GirsanovReweightingEstimator
 
     ReactiveFlux
     reactive_flux
@@ -52,6 +53,7 @@ from . import tools  # former msmtools
 from ._base import BayesianMSMPosterior, _MSMBaseEstimator
 from ._pcca import pcca, PCCAModel
 from ._transition_counting import TransitionCountEstimator, TransitionCountModel
+from ._girsanov_reweighted_transition_counting import GirsanovReweightingEstimator
 
 from ._reactive_flux import ReactiveFlux, reactive_flux
 

--- a/deeptime/markov/_girsanov_reweighted_transition_counting.py
+++ b/deeptime/markov/_girsanov_reweighted_transition_counting.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.sparse import issparse
 from .tools import estimation as msmest
 from ._transition_counting import TransitionCountModel, TransitionCountEstimator
-from ..util.types import ensure_dtraj_list
+from ..util.types import ensure_dtraj_list, ensure_factors_list
 
 
 class GirsanovReweightingEstimator(TransitionCountEstimator):
@@ -104,7 +104,12 @@ class GirsanovReweightingEstimator(TransitionCountEstimator):
         >>> np.testing.assert_equal(reweighted_counts.count_matrix, np.array([[1, 2], [1, 2]]))
         >>> print(reweighted_counts.count_matrix)
         """ 
-        count_matrix = msmest.girsanov_reweighted_count_matrix(dtrajs, lagtime, reweighting_factors, 
-                                                      sliding=True, sparse_return=sparse)
-
+        if count_mode == 'sliding':
+            reweighting_factors=(ensure_factors_list(reweighting_factors[0]),ensure_factors_list(reweighting_factors[1]))
+            count_matrix = msmest.girsanov_reweighted_count_matrix(dtrajs, lagtime, reweighting_factors, 
+                                                                   sliding=True, sparse_return=sparse)
+        elif count_mode in {'sample','effective','sliding-effective'}:
+            raise ValueError('Count mode {} is not compatible with the Girsanov reweighting estimator.'.format(count_mode))
+        else:
+            raise ValueError('Count mode {} is unknown.'.format(count_mode))
         return count_matrix

--- a/deeptime/markov/_girsanov_reweighted_transition_counting.py
+++ b/deeptime/markov/_girsanov_reweighted_transition_counting.py
@@ -1,0 +1,110 @@
+r"""This module implements an estimator for Girsanov path reweighting for Markov state models.
+.. moduleauthor:: J.-L.Schäfer <joana-lysiane DOT schaefer AT fu-berlin DOT de>
+"""
+
+from typing import Optional, List
+import numpy as np
+from scipy.sparse import issparse
+from .tools import estimation as msmest
+from ._transition_counting import TransitionCountModel, TransitionCountEstimator
+from ..util.types import ensure_dtraj_list
+
+
+class GirsanovReweightingEstimator(TransitionCountEstimator):
+
+    def __init__(self, lagtime: int, count_mode: str, n_states=None, sparse=False):
+        super().__init__(lagtime=lagtime, count_mode=count_mode,  n_states=n_states, sparse=sparse)
+        self.lagtime = lagtime 
+        self.count_mode = count_mode
+        self.sparse = sparse
+        self.n_states = n_states
+
+    def fetch_model(self) -> Optional[TransitionCountModel]:
+        r"""
+        Yields the latest estimated :class:`TransitionCountModel`. Might be None if fetched before any data was fit.
+        Returns
+        -------
+        The latest :class:`TransitionCountModel` or None.
+        """
+        return self._model
+
+    def fit(self, data, reweighting_factors, *args, **kw):  
+        r""" Counts transitions at given lag time according to configuration of the estimator.
+        Parameters
+        ----------
+        data : array_like or list of array_like
+            discretized trajectories; check for same length of random number array :code:`eta`, 
+            discrete trajectory and reweighting factors; note, most integrator give trajectories of length
+        reweighting_factors: tuple 
+            tuple of reweighting factors :code:`(g,M)`
+             :code:`g` is the likelihood ratio between probability measures with :code:`dim=(len(dtraj)-lag-1)`. 
+             :code:`M` is the likelihood ratio between the path probabilitiy densities with :code:`dim=(len(dtraj)-lag-1)`. 
+        """
+        dtrajs = ensure_dtraj_list(data)
+
+        # Compute count matrix
+        count_matrix = GirsanovReweightingEstimator.count(self.count_mode , dtrajs, self.lagtime, 
+                                                      reweighting_factors=reweighting_factors,
+                                                      sparse=self.sparse)
+        
+        # basic count statistics like in deeptime._transition_counting.TransitionCountEstimator
+        from deeptime.markov import count_states
+         
+        histogram = count_states(dtrajs, ignore_negative=True) 
+        
+        if self.n_states is not None and self.n_states > count_matrix.shape[0]:
+            histogram = np.pad(histogram, pad_width=[(0, self.n_states - count_matrix.shape[0])])
+            if issparse(count_matrix):
+                count_matrix = scipy.sparse.csr_matrix((count_matrix.data, count_matrix.indices, count_matrix.indptr),
+                                                       shape=(self.n_states, self.n_states))
+            else:
+                n_pad = self.n_states - count_matrix.shape[0]
+                count_matrix = np.pad(count_matrix, pad_width=[(0, n_pad), (0, n_pad)])
+
+        self._model = TransitionCountModel(
+            count_matrix=count_matrix, counting_mode=self.count_mode, lagtime=self.lagtime, 
+            state_histogram=histogram
+        )
+        return self
+
+    @staticmethod
+    def count(count_mode: str, dtrajs: List[np.ndarray], lagtime: int, reweighting_factors: tuple, 
+              sparse: bool = False):
+        r""" Computes a reweighted count matrix according to Girsanov path reweighting for Markov state models 
+        based on the sliding mode, discrete trajectories, a lagtime, the precomputed reweighting factors and
+        whether to use sparse matrices.
+        Parameters
+        ----------
+        count_mode : str
+            The counting mode to be used so far is "sliding".
+            See :meth:`__init__` for a more detailed description.
+        dtrajs : array_like or list of array_like
+            Discrete trajectories, i.e., a list of arrays which contain non-negative integer values. A single ndarray
+            can also be passed, which is then treated as if it was a list with that one ndarray in it.
+        lagtime : int
+            Distance between two frames in the discretized trajectories under which their potential change of state
+            is considered a transition.
+        sparse : bool, default=False
+            Whether to use sparse matrices or dense matrices. Sparse matrices can make sense when dealing with a lot of
+            states.
+        Returns
+        -------
+        count_matrix : (N, N) ndarray or sparse array
+            The computed count matrix. Can be ndarray or sparse depending on whether sparse was set to true or false.
+            N is the number of encountered states, i.e., :code:`np.max(dtrajs)+1`.
+        Example
+        -------
+        >>> from deeptime.markov import GirsanovReweightingEstimator
+        >>> dtrajs = np.array([0,0,1,1,0,1,0,1,1])
+        >>> _reweighting = (np.array([1,1,1,1,1,1]),np.array([1,1,1,1,1,1]))
+        >>> reweighted_counts_estimator = GirsanovReweightingEstimator(lagtime=1,
+        ...                                                            count_mode='sliding')
+        >>> reweighted_counts = reweighted_counts_estimator.fit(dtrajs[:-1],
+        ...                                                     reweighting_factors=_reweighting).fetch_model()
+        >>> np.testing.assert_equal(reweighted_counts.count_matrix, np.array([[1, 2], [1, 2]]))
+        >>> print(reweighted_counts.count_matrix)
+        """ 
+        count_matrix = msmest.girsanov_reweighted_count_matrix(dtrajs, lagtime, reweighting_factors, 
+                                                      sliding=True, sparse_return=sparse)
+
+        return count_matrix

--- a/deeptime/markov/_girsanov_reweighted_transition_counting.py
+++ b/deeptime/markov/_girsanov_reweighted_transition_counting.py
@@ -1,5 +1,5 @@
 r"""This module implements an estimator for Girsanov path reweighting for Markov state models.
-.. moduleauthor:: J.-L.Schäfer <joana-lysiane DOT schaefer AT fu-berlin DOT de>
+.. moduleauthor:: J.-L.Schaefer <joana-lysiane DOT schaefer AT fu-berlin DOT de>
 """
 
 from typing import Optional, List

--- a/deeptime/markov/_transition_counting.py
+++ b/deeptime/markov/_transition_counting.py
@@ -569,11 +569,13 @@ class TransitionCountEstimator(EstimatorTransformer):
                                                       n_jobs=kw.pop('n_jobs', None))
         if self.n_states is not None and self.n_states > count_matrix.shape[0]:
             histogram = np.pad(histogram, pad_width=[(0, self.n_states - count_matrix.shape[0])])
+            n_pad = self.n_states - count_matrix.shape[0]
             if issparse(count_matrix):
-                count_matrix = scipy.sparse.csr_matrix((count_matrix.data, count_matrix.indices, count_matrix.indptr),
+                indptr = np.pad(count_matrix.indptr, pad_width=[(0, n_pad)], 
+                                constant_values=count_matrix.indptr[-1])
+                count_matrix = scipy.sparse.csr_matrix((count_matrix.data, count_matrix.indices, indptr),
                                                        shape=(self.n_states, self.n_states))
             else:
-                n_pad = self.n_states - count_matrix.shape[0]
                 count_matrix = np.pad(count_matrix, pad_width=[(0, n_pad), (0, n_pad)])
 
         # initially state symbols, full count matrix, and full histogram can be left None because they coincide

--- a/deeptime/markov/tools/estimation/__init__.py
+++ b/deeptime/markov/tools/estimation/__init__.py
@@ -15,6 +15,7 @@ Countmatrix
    :toctree: generated/
 
    count_matrix - estimate count matrix from discrete trajectories
+   girsanov_reweighted_count_matrix - reweights the estimate of count matrix
 
 Connectivity
 ============

--- a/deeptime/markov/tools/estimation/api.py
+++ b/deeptime/markov/tools/estimation/api.py
@@ -281,7 +281,7 @@ def girsanov_reweighted_count_matrix(dtraj, lag, reweighting_factors,
 
     >>> C_sliding.toarray()
     array([[1., 2.],
-           [0., 1.]])
+           [1., 1.]])
 
     """
     # convert dtraj input, if it contains out of nested python lists to

--- a/deeptime/markov/tools/estimation/api.py
+++ b/deeptime/markov/tools/estimation/api.py
@@ -14,7 +14,7 @@ from scipy.sparse import coo_matrix
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
 
-from deeptime.util.types import ensure_dtraj_list
+from deeptime.util.types import ensure_dtraj_list, ensure_reweighting_factors_tuple
 from . import dense
 from . import sparse
 
@@ -216,7 +216,7 @@ def effective_count_matrix(dtrajs, lag, average='row', mact=1.0, n_jobs=None, ca
 
 def girsanov_reweighted_count_matrix(dtraj, lag, reweighting_factors,
                                      sliding=True, sparse_return=True, nstates=None):
-    r"""Generate a Girsanov reweighted count matrix from given microstate trajectory. :footcite:`donati2017girsanov`
+    r"""Generate a Girsanov reweighted count matrix from given microstate trajectory. :footcite:`schaefer2024implementation`
 
     Parameters
     ----------
@@ -262,14 +262,14 @@ def girsanov_reweighted_count_matrix(dtraj, lag, reweighting_factors,
     >>> import numpy as np
     >>> from deeptime.markov.tools.estimation import girsanov_reweighted_count_matrix
 
-    >>> dtraj = np.array([0, 0, 1, 0, 1, 1, 0])
+    >>> dtraj = np.array([0, 0, 1, 0, 1, 1, 0, 0])
     >>> tau = 2
 
     In this example, the bias and target potential would be the same. 
     Subtract the one to get the same length of the discrete trajectory :code:`len(eta+1)` and random number array :code:`eta`.
     
-    >>> g = np.ones(len(dtraj)-tau-1) 
-    >>> M = np.ones(len(dtraj)-tau-1)
+    >>> g = [np.ones(len(dtraj)-1)] 
+    >>> M = [np.zeros(len(dtraj)-1)]
     >>> reweighting_factors = (g,M)
 
     Use the reweighting approach as
@@ -281,12 +281,14 @@ def girsanov_reweighted_count_matrix(dtraj, lag, reweighting_factors,
 
     >>> C_sliding.toarray()
     array([[1., 2.],
-           [1., 1.]])
+           [0., 1.]])
 
     """
     # convert dtraj input, if it contains out of nested python lists to
     # a list of int ndarrays.
     dtraj = ensure_dtraj_list(dtraj)
+    # tuple of list of float ndarrays of shape dtraj
+    reweighting_factors = ensure_reweighting_factors_tuple(reweighting_factors)
     ## calles the new argument for girsanov reweighting 
     return sparse.count_matrix.count_matrix_coo2_mult(dtraj, lag, reweighting_factors,
                                                       sliding=sliding, sparse=sparse_return, nstates=nstates)

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -25,12 +25,10 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     lag : int
         Lagtime in trajectory steps
     reweighting: tuple, optional
-        Enforce a count-matrix with reweighting factors shape=(g,logM). g is the state-space 
+        Enforce a count-matrix with reweighting factors shape=(g,logM), :footcite:`schaefer2024implementation`. g is the state-space 
         probability density ratio. logM is the pre-expression of the M reweighting factor, 
         negative sign and exponent is realised in summation over the path of length lagtime.  
         The tuple gives two lists of ndarrays for g and logM, which must have the shape of dtraj.
-        Note: dtraj can be one time step longer than the g and M simulation output. 
-        In this case, the last step in dtraj must be deleted.
     sliding : bool, optional
         If true the sliding window approach
         is used for transition counting
@@ -71,18 +69,18 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     if reweighting_factors is None:
         data = np.ones(row.size)
     elif type(reweighting_factors) is tuple:
-        g_factors, M_factors = reweighting_factors
-        factors=[]
-        for g,M in zip(g_factors,M_factors):
-            if g.size > lag:
-                if sliding:
+        if sliding:
+            g_factors, M_factors = reweighting_factors
+            factors = []
+            for g,M in zip(g_factors, M_factors):
+                if g.size > lag:
                     m = M.cumsum()
                     m[lag:] = m[lag:] - m[:len(m)-lag]
                     m = m[(lag):]
                     m = np.exp(-m)
                     factors.append(g[0:-lag]*m)
-                else:
-                    raise NotImplementedError('Only the sliding scheme is implemented.')
+        else:
+            raise NotImplementedError('Only the sliding scheme is implemented.')
         factors = np.concatenate(factors)
         data = factors
     else:
@@ -93,3 +91,4 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
         return C.tocsr()
     else:
         return C.toarray()
+    

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -64,7 +64,6 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     # feed into one COO matrix
     row = np.concatenate(rows)
     col = np.concatenate(cols)
-    data = np.ones(row.size)
     ## choose option for including reweighting factors g and M
     if reweighting_factors is None:
         data = np.ones(row.size)

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -11,7 +11,8 @@ import scipy.sparse
 # count_matrix
 ################################################################################
 
-def count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True, nstates=None):
+def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None, 
+                           sliding=True, sparse=True, nstates=None):
     r"""Generate a count matrix from a given list discrete trajectories.
 
     The generated count matrix is a sparse matrix in compressed

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -75,10 +75,14 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     	factors=[]
     	for g,M in zip(g_factors,M_factors):
     		if g.size > lag:
-    			if sliding:
-    				factors.append(g[0:-lag]*M[0:-lag])
-    			else:
-    				factors.append(g[0:-lag:lag]*M[0:-lag:lag])
+                if sliding:
+                    m = M.cumsum()
+                    m[lag:] = m[lag:] - m[:len(m)-lag]
+                    m = m[(lag):]
+                    m = np.exp(-m)
+                    factors.append(g[0:-lag]*m)
+                else:
+                    raise NotImplementedError('Only the sliding scheme is implemented.')
     	factors = np.concatenate(factors)
     	data = factors
     else:

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -71,10 +71,10 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     if reweighting_factors is None:
         data = np.ones(row.size)
     elif type(reweighting_factors) is tuple:
-    	g_factors, M_factors = reweighting_factors
-    	factors=[]
-    	for g,M in zip(g_factors,M_factors):
-    		if g.size > lag:
+        g_factors, M_factors = reweighting_factors
+        factors=[]
+        for g,M in zip(g_factors,M_factors):
+            if g.size > lag:
                 if sliding:
                     m = M.cumsum()
                     m[lag:] = m[lag:] - m[:len(m)-lag]
@@ -83,8 +83,8 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
                     factors.append(g[0:-lag]*m)
                 else:
                     raise NotImplementedError('Only the sliding scheme is implemented.')
-    	factors = np.concatenate(factors)
-    	data = factors
+        factors = np.concatenate(factors)
+        data = factors
     else:
         raise NotImplementedError('An input format other than a tuple (g,M) for the reweighting factors is not implemented.')
     C = scipy.sparse.coo_matrix((data, (row, col)), shape=(nstates, nstates))

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -23,6 +23,9 @@ def count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True, nstates=None)
         discrete trajectories
     lag : int
         Lagtime in trajectory steps
+    reweighting: tuple, optional
+        Enforce a count-matrix with reweighting factors shape=(g,M). g is the ... with dim=().
+        M is .. with dim=(). 
     sliding : bool, optional
         If true the sliding window approach
         is used for transition counting
@@ -37,7 +40,6 @@ def count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True, nstates=None)
     C : scipy.sparse.csr_matrix or numpy.ndarray
         The countmatrix at given lag in scipy compressed sparse row
         or numpy ndarray format.
-
     """
     # Determine number of states
     if nstates is None:
@@ -61,6 +63,14 @@ def count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True, nstates=None)
     row = np.concatenate(rows)
     col = np.concatenate(cols)
     data = np.ones(row.size)
+    ## choose option for including reweighting factors g and M
+    if reweighting_factors is None:
+        data = np.ones(row.size)
+    elif type(reweighting_factors) is tuple:
+        g, M = reweighting_factors
+        data = g * M
+    else:
+        raise NotImplementedError('An input format other than a tuple (g,M) for the reweighting factors is not implemented.')
     C = scipy.sparse.coo_matrix((data, (row, col)), shape=(nstates, nstates))
     # export to output format
     if sparse:

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -25,12 +25,12 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     lag : int
         Lagtime in trajectory steps
     reweighting: tuple, optional
-        Enforce a count-matrix with reweighting factors shape=(g,M). g is the 
-        state-space probability density likelihood ratio. M is the likelihood 
-        ratio between path probability densities.  The tuple gives two lists 
-        of ndarrays for g and M, which must have the shape of dtraj.
-        Attention: dtraj can be one time step longer than the g and M simulation 
-        output. In this case, delete the last step in dtraj.
+        Enforce a count-matrix with reweighting factors shape=(g,logM). g is the state-space 
+        probability density ratio. logM is the pre-expression of the M reweighting factor, 
+        negative sign and exponent is realised in summation over the path of length lagtime.  
+        The tuple gives two lists of ndarrays for g and logM, which must have the shape of dtraj.
+        Note: dtraj can be one time step longer than the g and M simulation output. 
+        In this case, the last step in dtraj must be deleted.
     sliding : bool, optional
         If true the sliding window approach
         is used for transition counting

--- a/deeptime/markov/tools/estimation/sparse/count_matrix.py
+++ b/deeptime/markov/tools/estimation/sparse/count_matrix.py
@@ -25,8 +25,9 @@ def count_matrix_coo2_mult(dtrajs, lag, reweighting_factors=None,
     lag : int
         Lagtime in trajectory steps
     reweighting: tuple, optional
-        Enforce a count-matrix with reweighting factors shape=(g,M). g is the ... with dim=().
-        M is .. with dim=(). 
+        Enforce a count-matrix with reweighting factors shape=(g,M). g is the state-space probability 
+        density likelihood ratio with dim=().
+        M is the likelihood ratio between path probability densities with dim=(). 
     sliding : bool, optional
         If true the sliding window approach
         is used for transition counting

--- a/deeptime/util/types.py
+++ b/deeptime/util/types.py
@@ -126,11 +126,18 @@ def ensure_dtraj_list(dtrajs):
         return [ensure_integer_array(dtrajs)]
     return [ensure_integer_array(t) for t in dtrajs]
 
-def ensure_factors_list(factors):
-    """Makes sure that g_factors and M_factors are a list of reweighting factors (array of int)"""
-    if len(factors) > 0 and isinstance(factors[0], numbers.Real):
-        return [ensure_integer_array(factors)]
-    return [ensure_integer_array(t) for t in factors]
+def ensure_reweighting_factors_tuple(reweighting_factors):
+    """Makes sure that g_factors and M_factors are a tuple of a list of reweighting factors (array of float)"""
+    if len(reweighting_factors) == 2 and isinstance(reweighting_factors, tuple) and isinstance(reweighting_factors[0], (list, np.ndarray)) and isinstance(reweighting_factors[0][0], (float, int)):
+        return tuple([[ensure_floating_array(factor_traj)] for factor_traj in reweighting_factors])
+    elif len(reweighting_factors) == 2 and isinstance(reweighting_factors, tuple) and isinstance(reweighting_factors[0], (list, np.ndarray)) and isinstance(reweighting_factors[0][0], (list, np.ndarray)):
+        return tuple([[ensure_floating_array(factor_traj) for factor_traj in factor_list] for factor_list in reweighting_factors])
+    elif len(reweighting_factors) == 2 and isinstance(reweighting_factors, (list, np.ndarray)) and isinstance(reweighting_factors[0], (list, np.ndarray)) and isinstance(reweighting_factors[0][0], (float, int)):
+        return tuple([[ensure_floating_array(factor_traj)] for factor_traj in reweighting_factors])
+    elif len(reweighting_factors) == 2 and isinstance(reweighting_factors, (list, np.ndarray)) and isinstance(reweighting_factors[0], (list, np.ndarray)) and isinstance(reweighting_factors[0][0], (list, np.ndarray)):
+        return tuple([[ensure_floating_array(factor_traj) for factor_traj in factor_list] for factor_list in reweighting_factors])
+    else:
+        raise ValueError("The reweighting_factors input must be a tuple of lists for arrays of g and M reweighting factor.")
 
 def ensure_timeseries_data(input_data) -> List[np.ndarray]:
     r""" Ensures that the input data is a time series. This means it must be an iterable of ndarrays or an ndarray

--- a/deeptime/util/types.py
+++ b/deeptime/util/types.py
@@ -126,6 +126,11 @@ def ensure_dtraj_list(dtrajs):
         return [ensure_integer_array(dtrajs)]
     return [ensure_integer_array(t) for t in dtrajs]
 
+def ensure_factors_list(factors):
+    """Makes sure that g_factors and M_factors are a list of reweighting factors (array of int)"""
+    if len(factors) > 0 and isinstance(factors[0], numbers.Real):
+        return [ensure_integer_array(factors)]
+    return [ensure_integer_array(t) for t in factors]
 
 def ensure_timeseries_data(input_data) -> List[np.ndarray]:
     r""" Ensures that the input data is a time series. This means it must be an iterable of ndarrays or an ndarray

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -700,3 +700,19 @@
   year={1999},
   publisher={World Scientific}
 }
+@article{donati2017girsanov,
+  title={Girsanov reweighting for path ensembles and Markov state models},
+  author={Donati, Lorenzo and Hartmann, Carsten and Keller, Bettina G},
+  journal={The Journal of chemical physics},
+  volume={146},
+  number={24},
+  year={2017},
+  publisher={AIP Publishing}
+}
+@article{schaefer2024implementation,
+    title={Implementation of Girsanov Reweighting in OpenMM and Deeptime},
+    author={Schaefer, Joana-Lysiane and Keller, Bettina G},
+  journal={The Journal of Physical Chemistry B},
+  year={2024},
+  publisher={ACS Publications}
+}

--- a/tests/markov/test_girsanov_reweighted_transition_counting.py
+++ b/tests/markov/test_girsanov_reweighted_transition_counting.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_equal, assert_array_equal
+
+from deeptime.markov import TransitionCountEstimator, GirsanovReweightingEstimator
+
+class TestGirsanovReweightingEstimator(unittest.TestCase):
+
+    def test_properties(self):
+        valid_count_modes = "sample", "sliding", "sliding-effective", "effective"
+        for mode in valid_count_modes:
+            estimator = GirsanovReweightingEstimator(lagtime=5, count_mode=mode)
+            self.assertEqual(estimator.count_mode, mode)
+            assert_equal(estimator.lagtime, 5)
+
+    def test_sample_counting(self):
+        dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
+        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sample")
+        with self.assertRaises(ValueError):
+            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()
+
+    def test_sliding_counting(self):
+        dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
+        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        rwght_estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sliding")
+        rwght_model = rwght_estimator.fit(dtraj,reweighting_factors=_reweighting).fetch_model()
+        estimator = TransitionCountEstimator(lagtime=2, count_mode="sliding")
+        model = estimator.fit(dtraj).fetch_model()
+        # sliding window across trajectory counting transitions, overestimating total count:
+        # 0 -> 0, 0 -> 0, 0 -> 1, 0-> 1, 1-> 0, 1-> 1
+        # relative values to compare with unweighted count matrix -> np.array([[2.,2.],[1.,1.]])/2.
+        assert_array_equal(rwght_model.count_matrix/np.max(rwght_model.count_matrix), model.count_matrix/np.max(model.count_matrix))
+        assert_equal(rwght_model.lagtime, 2)
+        assert rwght_model.counting_mode == "sliding", "expected sliding counting mode, got {}".format(rwght_model.counting_mode)
+        assert_equal(rwght_model.state_symbols, [0, 1], err_msg="Trajectory only contained states 0 and 1")
+        assert_equal(rwght_model.n_states, 2)
+        assert_equal(rwght_model.state_histogram, [5, 3])
+        assert rwght_model.is_full_model
+        assert_equal(rwght_model.selected_count_fraction, 1)
+        assert_equal(rwght_model.selected_state_fraction, 1)
+        assert_equal(rwght_model.total_count, len(dtraj))
+        assert_equal(rwght_model.visited_set, [0, 1])
+
+    def test_sliding_effective_counting(self):
+        dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
+        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sliding-effective")
+        with self.assertRaises(ValueError):
+            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()
+
+    def test_effective_counting(self):
+        dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
+        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="effective")
+        with self.assertRaises(ValueError):
+            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()

--- a/tests/markov/test_girsanov_reweighted_transition_counting.py
+++ b/tests/markov/test_girsanov_reweighted_transition_counting.py
@@ -13,17 +13,19 @@ class TestGirsanovReweightingEstimator(unittest.TestCase):
             estimator = GirsanovReweightingEstimator(lagtime=5, count_mode=mode)
             self.assertEqual(estimator.count_mode, mode)
             assert_equal(estimator.lagtime, 5)
+            assert_equal(estimator.n_states, None)
+            assert_equal(estimator.sparse, False)        
 
     def test_sample_counting(self):
         dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
-        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        _reweighting = (np.array([1., 1., 1., 1., 1., 1., 1., 1.]),np.array([1., 1., 1., 1., 1., 1., 1., 1.]))
         estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sample")
         with self.assertRaises(ValueError):
-            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()
+            estimator.fit(dtraj, reweighting_factors=_reweighting).fetch_model()
 
     def test_sliding_counting(self):
         dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
-        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        _reweighting = (np.array([1., 1., 1., 1., 1., 1., 1., 1.]),np.array([1., 1., 1., 1., 1., 1., 1., 1.]))
         rwght_estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sliding")
         rwght_model = rwght_estimator.fit(dtraj,reweighting_factors=_reweighting).fetch_model()
         estimator = TransitionCountEstimator(lagtime=2, count_mode="sliding")
@@ -43,16 +45,58 @@ class TestGirsanovReweightingEstimator(unittest.TestCase):
         assert_equal(rwght_model.total_count, len(dtraj))
         assert_equal(rwght_model.visited_set, [0, 1])
 
+    def test_sliding_representation(self):
+        dtraj = [np.array([0, 0, 1, 0, 1, 1, 0])]
+        gtraj = [np.array([1., 1., 1., 1., 1., 1., 1.])]
+        Mtraj = [np.array([0., 0., 0., 0., 0., 0., 0.])]
+        counts_sliding = np.array([[1, 2], [2, 1]])
+        counts_sliding_4nstates = np.array([[1, 2, 0, 0], [2, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        # automatic detection of n_states, sparse=False
+        estimator= TransitionCountEstimator(1,'sliding')
+        counts = estimator.fit(dtraj).fetch_model()
+        rwght_estimator= GirsanovReweightingEstimator(1,'sliding')
+        counts_rwght = rwght_estimator.fit(dtraj,(gtraj,Mtraj)).fetch_model()
+        assert_equal(counts.count_matrix,counts_rwght.count_matrix)
+        assert_equal(counts_sliding,counts_rwght.count_matrix)
+        # automatic detection of n_states, sparse=True
+        estimator= TransitionCountEstimator(1,'sliding', sparse=True)
+        counts = estimator.fit(dtraj).fetch_model()
+        rwght_estimator= GirsanovReweightingEstimator(1,'sliding', sparse=True)
+        counts_rwght = rwght_estimator.fit(dtraj,(gtraj,Mtraj)).fetch_model()
+        assert_equal(counts.state_histogram,counts_rwght.state_histogram)
+        assert_equal(counts.count_matrix.data,counts_rwght.count_matrix.data)
+        assert_equal(counts.count_matrix.indices,counts_rwght.count_matrix.indices)
+        assert_equal(counts.count_matrix.indptr,counts_rwght.count_matrix.indptr)
+        assert_equal(counts_sliding,counts_rwght.count_matrix.toarray())
+        # set n_states > count_matrix shape, sparse=False
+        estimator= TransitionCountEstimator(1,'sliding',n_states=4)
+        counts = estimator.fit(dtraj).fetch_model()
+        rwght_estimator= GirsanovReweightingEstimator(1,'sliding',n_states=4)
+        counts_rwght = rwght_estimator.fit(dtraj,(gtraj,Mtraj)).fetch_model()
+        assert_equal(counts.count_matrix,counts_rwght.count_matrix)
+        assert_equal(counts_sliding_4nstates,counts_rwght.count_matrix)
+        # set n_states > count_matrix shape, sparse=False
+        estimator= TransitionCountEstimator(1,'sliding',n_states=4, sparse=True)
+        counts = estimator.fit(dtraj).fetch_model()
+        counts.count_matrix.toarray()
+        rwght_estimator= GirsanovReweightingEstimator(1,'sliding',n_states=4, sparse=True)
+        counts_rwght = rwght_estimator.fit(dtraj,(gtraj,Mtraj)).fetch_model()
+        assert_equal(counts.state_histogram,counts_rwght.state_histogram)
+        assert_equal(counts.count_matrix.data,counts_rwght.count_matrix.data)
+        assert_equal(counts.count_matrix.indices,counts_rwght.count_matrix.indices)
+        assert_equal(counts.count_matrix.indptr,counts_rwght.count_matrix.indptr)
+        assert_equal(counts_sliding_4nstates,counts_rwght.count_matrix.toarray())
+
     def test_sliding_effective_counting(self):
         dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
-        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        _reweighting = (np.array([1., 1., 1., 1., 1., 1., 1., 1.]),np.array([1., 1., 1., 1., 1., 1., 1., 1.]))
         estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="sliding-effective")
         with self.assertRaises(ValueError):
-            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()
+            estimator.fit(dtraj, reweighting_factors=_reweighting).fetch_model()
 
     def test_effective_counting(self):
         dtraj = np.array([0, 0, 0, 0, 1, 1, 0, 1])
-        _reweighting = (np.array([1, 1, 1, 1, 1, 1, 1, 1]),np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+        _reweighting = (np.array([1., 1., 1., 1., 1., 1., 1., 1.]),np.array([1., 1., 1., 1., 1., 1., 1., 1.]))
         estimator = GirsanovReweightingEstimator(lagtime=2, count_mode="effective")
         with self.assertRaises(ValueError):
-            estimator.fit(dtraj[:-1], reweighting_factors=_reweighting).fetch_model()
+            estimator.fit(dtraj, reweighting_factors=_reweighting).fetch_model()

--- a/tests/markov/tools/estimation/tests/test_girsanov_reweighted_count_matrix.py
+++ b/tests/markov/tools/estimation/tests/test_girsanov_reweighted_count_matrix.py
@@ -1,0 +1,288 @@
+import unittest
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from tests.markov.tools.numeric import assert_allclose
+
+from os.path import abspath, join
+from os import pardir
+
+from deeptime.markov.tools.estimation import girsanov_reweighted_count_matrix
+
+testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
+
+
+class TestGirsanovReweightedCountMatrixMult(unittest.TestCase):
+    def setUp(self):
+        M = 10
+        self.M = M
+
+        """Small test cases"""
+        dtraj_short = np.array([0, 0, 1, 0, 1, 1, 0])
+        self.dtrajs_short = [dtraj_short for i in range(M)]
+
+        gtraj_short = np.array([1., 1., 1., 1., 1., 1., 1.])
+        self.gtrajs_short = [gtraj_short for i in range(M)]
+
+        Mtraj_short = np.array([0., 0., 0., 0., 0., 0., 0.])
+        self.Mtrajs_short = [Mtraj_short for i in range(M)]
+
+        self.B1_sliding = M * np.array([[1, 2], [2, 1]])
+        self.B2_sliding = M * np.array([[1, 2], [1, 1]])
+        self.B3_sliding = M * np.array([[2, 1], [0, 1]])
+
+        self.B1_sliding_4nstates = M * np.array([[1, 2, 0, 0], [2, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        self.B2_sliding_4nstates = M * np.array([[1, 2, 0, 0], [1, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        self.B3_sliding_4nstates = M * np.array([[2, 1, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+
+        """Larger test cases"""
+        dtraj_long = np.loadtxt(testpath + 'dtraj.dat').astype(int)
+        self.gtrajs_long = [np.ones(len(dtraj_long))  for i in range(M)]
+        self.Mtrajs_long = [np.zeros(len(dtraj_long)) for i in range(M)]
+        self.dtrajs_long = [dtraj_long for i in range(M)]
+      
+        self.C1_sliding = M * np.loadtxt(testpath + 'C_1_sliding.dat')
+        self.C7_sliding = M * np.loadtxt(testpath + 'C_7_sliding.dat')
+        self.C13_sliding = M * np.loadtxt(testpath + 'C_13_sliding.dat')
+
+    def tearDown(self):
+        pass
+
+    def test_girsanov_reweighted_count_matrix_mult(self):
+        """Small test cases"""
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short)).toarray()
+        assert_allclose(C, self.B1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 2, (self.gtrajs_short, self.Mtrajs_short)).toarray()
+        assert_allclose(C, self.B2_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 3, (self.gtrajs_short, self.Mtrajs_short)).toarray()
+        assert_allclose(C, self.B3_sliding)
+
+        """Larger test cases"""
+        C = girsanov_reweighted_count_matrix(self.dtrajs_long, 1, (self.gtrajs_long, self.Mtrajs_long)).toarray()
+        assert_allclose(C, self.C1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_long, 7, (self.gtrajs_long, self.Mtrajs_long)).toarray()
+        assert_allclose(C, self.C7_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_long, 13, (self.gtrajs_long, self.Mtrajs_long)).toarray()
+        assert_allclose(C, self.C13_sliding)
+
+        """Test raising of value error if lag greater than trajectory length"""
+        with self.assertRaises(ValueError):
+            C = girsanov_reweighted_count_matrix(self.dtrajs_short, 10, (self.gtrajs_short, self.Mtrajs_short))
+
+    def test_sliding_keyword(self):
+        with self.assertRaises(NotImplementedError):
+            C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), sliding=False)
+
+    def test_sparse_return_keyword(self):
+        # dense representation
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), sparse_return=False)
+        assert_allclose(C, self.B1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B1_sliding_4nstates)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 2, (self.gtrajs_short, self.Mtrajs_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B2_sliding_4nstates)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 3, (self.gtrajs_short, self.Mtrajs_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B3_sliding_4nstates)
+
+        # sparse representation
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), sparse_return=True)
+        assert_allclose(C.data, csr_matrix(self.B1_sliding).data)
+        assert_allclose(C.indices, csr_matrix(self.B1_sliding).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B1_sliding).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B1_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B1_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B1_sliding_4nstates).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 2, (self.gtrajs_short, self.Mtrajs_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B2_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B2_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B2_sliding_4nstates).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 3, (self.gtrajs_short, self.Mtrajs_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B3_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B3_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B3_sliding_4nstates).indptr)
+    
+    def test_nstates_keyword(self):
+        C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), nstates=10)
+        self.assertTrue(C.shape == (10, 10))
+
+        with self.assertRaises(ValueError):
+            C = girsanov_reweighted_count_matrix(self.dtrajs_short, 1, (self.gtrajs_short, self.Mtrajs_short), nstates=1)
+
+
+class TestGirsanovReweightedCountMatrix(unittest.TestCase):
+    def setUp(self):
+        """Small test cases"""
+        self.dtraj_short = np.array([0, 0, 1, 0, 1, 1, 0])
+        self.gtraj_short = np.array([1., 1., 1., 1., 1., 1., 1.])
+        self.Mtraj_short = np.array([0., 0., 0., 0., 0., 0., 0.])
+
+        self.B1_sliding = np.array([[1, 2], [2, 1]])
+        self.B2_sliding = np.array([[1, 2], [1, 1]])
+        self.B3_sliding = np.array([[2, 1], [0, 1]])
+
+        self.B1_sliding_4nstates = np.array([[1, 2, 0, 0], [2, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        self.B2_sliding_4nstates = np.array([[1, 2, 0, 0], [1, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        self.B3_sliding_4nstates = np.array([[2, 1, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+
+        """Larger test cases"""
+        self.dtraj_long = np.loadtxt(testpath + 'dtraj.dat').astype(int)
+        self.gtraj_long = np.ones(len(self.dtraj_long))  
+        self.Mtraj_long = np.zeros(len(self.dtraj_long)) 
+
+        self.C1_sliding = np.loadtxt(testpath + 'C_1_sliding.dat')
+        self.C7_sliding = np.loadtxt(testpath + 'C_7_sliding.dat')
+        self.C13_sliding = np.loadtxt(testpath + 'C_13_sliding.dat')
+
+    def tearDown(self):
+        pass
+
+    def test_girsanov_reweighted_count_matrix(self):
+        """Small test cases"""
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short)).toarray()
+        assert_allclose(C, self.B1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 2, (self.gtraj_short, self.Mtraj_short)).toarray()
+        assert_allclose(C, self.B2_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 3, (self.gtraj_short, self.Mtraj_short)).toarray()
+        assert_allclose(C, self.B3_sliding)
+
+        """Larger test cases"""
+        C = girsanov_reweighted_count_matrix(self.dtraj_long, 1, (self.gtraj_long, self.Mtraj_long)).toarray()
+        assert_allclose(C, self.C1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_long, 7, (self.gtraj_long, self.Mtraj_long)).toarray()
+        assert_allclose(C, self.C7_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_long, 13, (self.gtraj_long, self.Mtraj_long)).toarray()
+        assert_allclose(C, self.C13_sliding)
+
+        """Test raising of value error if lag greater than trajectory length"""
+        with self.assertRaises(ValueError):
+            C = girsanov_reweighted_count_matrix(self.dtraj_short, 10, (self.gtraj_short, self.Mtraj_short))
+
+    def test_sliding_keyword(self):
+        with self.assertRaises(NotImplementedError):
+            C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), sliding=False)
+
+    def test_sparse_return_keyword(self):
+        # dense representation
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), sparse_return=False)
+        assert_allclose(C, self.B1_sliding)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B1_sliding_4nstates)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 2, (self.gtraj_short, self.Mtraj_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B2_sliding_4nstates)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 3, (self.gtraj_short, self.Mtraj_short), sparse_return=False, nstates=4)
+        assert_allclose(C, self.B3_sliding_4nstates)
+
+        # sparse representation
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), sparse_return=True)
+        assert_allclose(C.data, csr_matrix(self.B1_sliding).data)
+        assert_allclose(C.indices, csr_matrix(self.B1_sliding).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B1_sliding).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B1_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B1_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B1_sliding_4nstates).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 2, (self.gtraj_short, self.Mtraj_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B2_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B2_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B2_sliding_4nstates).indptr)
+
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 3, (self.gtraj_short, self.Mtraj_short), sparse_return=True, nstates=4)
+        assert_allclose(C.data, csr_matrix(self.B3_sliding_4nstates).data)
+        assert_allclose(C.indices, csr_matrix(self.B3_sliding_4nstates).indices)
+        assert_allclose(C.indptr, csr_matrix(self.B3_sliding_4nstates).indptr)
+
+    
+    def test_nstates_keyword(self):
+        C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), nstates=10)
+        self.assertTrue(C.shape == (10, 10))
+
+        with self.assertRaises(ValueError):
+            C = girsanov_reweighted_count_matrix(self.dtraj_short, 1, (self.gtraj_short, self.Mtraj_short), nstates=1)
+
+class TestArguments(unittest.TestCase):
+    def testInputList(self):
+        dtrajs = [0, 1, 2, 0, 0, 1, 2, 1, 0]
+        gtrajs = np.ones(len(dtrajs))
+        Mtrajs = np.zeros(len(dtrajs))
+        girsanov_reweighted_count_matrix(dtrajs, 1, [list(gtrajs),list(Mtrajs)])
+        girsanov_reweighted_count_matrix(dtrajs, 1, (list(gtrajs),list(Mtrajs)))
+        
+
+    def testInputArray(self):
+        dtrajs = np.array([0, 1, 2, 0, 0, 1, 2, 1, 0])
+        gtrajs = np.ones(len(dtrajs))
+        Mtrajs = np.zeros(len(dtrajs))
+        girsanov_reweighted_count_matrix(dtrajs, 1, [gtrajs,Mtrajs])
+        girsanov_reweighted_count_matrix(dtrajs, 1, np.array([gtrajs,Mtrajs]))
+        girsanov_reweighted_count_matrix(dtrajs, 1, (gtrajs,Mtrajs))
+
+    def testInputNestedLists(self):
+        dtrajs = [[0, 1, 2, 0, 0, 1, 2, 1, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0, 2]]
+        gtrajs = np.ones_like(dtrajs).astype(float)
+        Mtrajs = np.zeros_like(dtrajs).astype(float)
+        girsanov_reweighted_count_matrix(dtrajs, 1, [gtrajs,Mtrajs])
+        girsanov_reweighted_count_matrix(dtrajs, 1, np.array([gtrajs,Mtrajs]))
+        girsanov_reweighted_count_matrix(dtrajs, 1, (gtrajs,Mtrajs))
+
+    def testInputNestedListsDiffSize(self):
+        dtrajs = [[0, 1, 2, 0, 0, 1, 2, 1, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0, 2, 1, 2, 1]]
+        gtrajs = [[1., 1, 1., 1, 1, 1, 1, 1, 1],
+                  [1., 1, 1, 1, 1, 1, 1, 1., 1, 1, 1, 1]]
+        Mtrajs = [[0, 0., 0, 0, 0, 0., 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0., 0., 0, 0, 0., 0, 0]]
+        girsanov_reweighted_count_matrix(dtrajs, 1, [gtrajs,Mtrajs])
+        girsanov_reweighted_count_matrix(dtrajs, 1, (gtrajs,Mtrajs))
+
+    def testInputInt(self):
+        '''int input for reweighting factors is not supported'''
+        dtrajs = [[0, 1, 2, 0, 0, 1, 2, 1, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0, 2]]
+        gtrajs = np.ones_like(dtrajs)
+        Mtrajs = np.zeros_like(dtrajs)
+        
+        with self.assertRaises(ValueError):
+            girsanov_reweighted_count_matrix(dtrajs, 1, (gtrajs,Mtrajs))
+
+    def testInputTupleOfTuple(self):
+        '''input for nested tuples for reweighting factors is not supported'''
+        dtrajs = [[0, 1, 2, 0, 0, 1, 2, 1, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0, 2]]
+        reweighting_factors = ((np.ones((9,)),np.ones((9,))),(np.ones((9,)),np.ones((9,))))
+        
+        with self.assertRaises(ValueError):
+            girsanov_reweighted_count_matrix(dtrajs, 1, reweighting_factors)
+
+    def testInputWrongShapes(self):
+        '''input for nested tuples for reweighting factors is not supported'''
+        dtrajs = [[0, 1, 2, 0, 0, 1, 2, 1, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0, 2]]
+        
+        reweighting_factors = ([np.ones((9,)),np.ones((9,)),np.ones((9,)),np.ones((9,))])
+        with self.assertRaises(ValueError):
+            girsanov_reweighted_count_matrix(dtrajs, 1, reweighting_factors)
+        
+        reweighting_factors = (np.ones((9,)),np.ones((9,)),np.ones((9,)),np.ones((9,)))
+        with self.assertRaises(ValueError):
+            girsanov_reweighted_count_matrix(dtrajs, 1, reweighting_factors)

--- a/tests/util/test_types.py
+++ b/tests/util/test_types.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.testing import assert_, assert_equal, assert_raises
 
 from deeptime.util.data import TrajectoryDataset
-from deeptime.util.types import to_dataset
+from deeptime.util.types import to_dataset, ensure_reweighting_factors_tuple
 
 
 @contextmanager
@@ -40,3 +40,15 @@ def test_to_dataset(data, lagtime, expectation):
         assert_equal(data[0].shape[1], 5)
         assert_equal(len(data[1]), len(ds))
         assert_equal(data[1].shape[1], 5)
+
+testdata = [
+    (([np.ones((6,))],[np.ones((6,))]),([np.ones((6,))],[np.ones((6,))])),
+    ((np.ones((6,)),np.ones((6,))),([np.ones((6,))],[np.ones((6,))])),
+    ([[np.ones((6,))],[np.ones((6,))]],([np.ones((6,))],[np.ones((6,))])), 
+    ([np.ones((6,)),np.ones((6,))],([np.ones((6,))],[np.ones((6,))])),
+    (([np.ones((6,)),np.ones((6,)),np.ones((6,))],[np.ones((6,)),np.ones((6,)),np.ones((6,))]),([np.ones((6,)),np.ones((6,)),np.ones((6,))],[np.ones((6,)),np.ones((6,)),np.ones((6,))])),
+    ([[np.ones((6,)),np.ones((6,))],[np.ones((6,)),np.ones((6,))]],([np.ones((6,)),np.ones((6,))],[np.ones((6,)),np.ones((6,))]))
+]
+@pytest.mark.parametrize("reweighting_factors, output", testdata)
+def test_ensure_reweighting_factors_tuple(reweighting_factors, output):
+    assert_equal(ensure_reweighting_factors_tuple(reweighting_factors), output)


### PR DESCRIPTION
We extended the MSM estimator class, such that the transition counts are reweighted according to the reweighting factor trajectory. 

Joana-Lysiane Schäfer, Bettina G. Keller, Implementation of Girsanov reweighting in OpenMM and Deeptime

We demonstrated the correct functioning and error-free applicability of the newly implemented
functions using both a low-dimensional test system and a molecular system. 
The corresponding reference "Implementation of Girsanov reweighting in OpenMM and Deeptime" is currently under review and will be publicly available shortly. 
The required input files and setup for the evaluation of a reweighted Markov state model are available at [reweightingtools](https://github.com/bkellerlab/reweightingtools)
